### PR TITLE
fix: silence npm output when running is-release-needed

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Check if version number has changed 🕵️‍♀️
       id: is_release_needed
-      run: npm run is-release-needed --workspace=${{ matrix.package }} >> $GITHUB_OUTPUT
+      run: npm run is-release-needed --workspace=${{ matrix.package }} --silent >> $GITHUB_OUTPUT
     - name: Setup .npmrc file to publish to npm 📝
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Towards https://github.com/RequestNetwork/docs.request.network/issues/27

# Changes

* Fix the publish workflow by silencing the npm output