### PR TITLE
chore: call `npm whoami` and `npm config get registry` during publish

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -47,4 +47,5 @@ jobs:
         if: steps.is-release-needed.outputs.is-release-needed == 'true'
         run: |
           npm config set registry https://registry.npmjs.org
+          npm whoami
           npm publish --workspace=${{ matrix.package }}

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -48,4 +48,5 @@ jobs:
         run: |
           npm config set registry https://registry.npmjs.org
           npm whoami
+          npm config get registry
           npm publish --workspace=${{ matrix.package }} --dry-run

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -48,4 +48,4 @@ jobs:
         run: |
           npm config set registry https://registry.npmjs.org
           npm whoami
-          npm publish --workspace=${{ matrix.package }}
+          npm publish --workspace=${{ matrix.package }} --dry-run

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -47,6 +47,6 @@ jobs:
         if: steps.is-release-needed.outputs.is-release-needed == 'true'
         run: |
           npm config set registry https://registry.npmjs.org
-          npm whoami
-          npm config get registry
+          npm whoami || { echo "Failed to identify npm user."; exit 1; }
+          npm config get registry || { echo "Failed to get npm registry."; exit 1; }
           npm publish --workspace=${{ matrix.package }} --dry-run


### PR DESCRIPTION
Towards #29 

# Changes

* call `npm whoami` and `npm config get registry` during publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved npm publish workflow by adding checks for user and registry configurations before performing a dry run publish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->