### PR TITLE
feat: added pdf download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@ethersproject/abi": {
       "version": "5.7.0",
       "funding": [
@@ -5665,6 +5676,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
+    },
     "node_modules/abitype": {
       "version": "1.0.0",
       "license": "MIT",
@@ -5769,6 +5786,17 @@
       "version": "0.4.0",
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "license": "MIT",
@@ -5799,6 +5827,14 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {
@@ -6080,6 +6116,17 @@
         "node": ">=4.5.0"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.2.1",
       "license": "MIT",
@@ -6148,6 +6195,31 @@
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
     },
     "node_modules/cbor-js": {
       "version": "0.1.0",
@@ -6295,6 +6367,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "license": "MIT"
@@ -6375,6 +6458,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -6550,6 +6641,12 @@
         "npm": ">=1.2"
       }
     },
+    "node_modules/dompurify": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.6.tgz",
+      "integrity": "sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==",
+      "optional": true
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "license": "MIT",
@@ -6721,6 +6818,11 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -7022,6 +7124,33 @@
     "node_modules/html-minifier-terser/node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2pdf.js": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.10.2.tgz",
+      "integrity": "sha512-WyHVeMb18Bp7vYTmBv1GVsThH//K7SRfHdSdhHPkl4JvyQarNQXnailkYn0QUbRRmnN5rdbbmSIGEsPZtzPy2Q==",
+      "dependencies": {
+        "es6-promise": "^4.2.5",
+        "html2canvas": "^1.0.0",
+        "jspdf": "^2.3.1"
+      }
+    },
+    "node_modules/html2pdf.js/node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/htmlescape": {
       "version": "1.1.1",
@@ -7361,6 +7490,23 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jssha": {
@@ -7958,6 +8104,12 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
+    },
     "node_modules/periscopic": {
       "version": "3.1.0",
       "dev": true,
@@ -8131,6 +8283,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "license": "MIT",
@@ -8188,6 +8349,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "license": "MIT",
@@ -8225,6 +8391,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -8506,6 +8681,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "license": "MIT",
@@ -8772,6 +8956,15 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/syntax-error": {
       "version": "1.4.0",
       "license": "MIT",
@@ -8808,6 +9001,14 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "license": "MIT"
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -9041,6 +9242,14 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/viem": {
       "version": "2.13.1",
@@ -9313,7 +9522,7 @@
     },
     "packages/create-invoice-form": {
       "name": "@requestnetwork/create-invoice-form",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/request-client.js": "0.47.1-next.2043",
@@ -9329,13 +9538,14 @@
     },
     "packages/invoice-dashboard": {
       "name": "@requestnetwork/invoice-dashboard",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/payment-detection": "0.43.1-next.2043",
         "@requestnetwork/payment-processor": "0.45.1-next.2043",
         "@requestnetwork/request-client.js": "0.47.1-next.2043",
         "ethers": "^5.7.2",
+        "html2pdf.js": "^0.10.2",
         "viem": "^2.9.15"
       },
       "devDependencies": {

--- a/packages/invoice-dashboard/package.json
+++ b/packages/invoice-dashboard/package.json
@@ -31,13 +31,14 @@
     "@requestnetwork/payment-detection": "0.43.1-next.2043",
     "@requestnetwork/payment-processor": "0.45.1-next.2043",
     "@requestnetwork/request-client.js": "0.47.1-next.2043",
-    "viem": "^2.9.15",
-    "ethers": "^5.7.2"
+    "ethers": "^5.7.2",
+    "html2pdf.js": "^0.10.2",
+    "viem": "^2.9.15"
   },
   "devDependencies": {
-    "svelte": "^4.0.5",
     "@sveltejs/package": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^2.5.2",
+    "svelte": "^4.0.5",
     "svelte-check": "^3.6.0",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",

--- a/packages/invoice-dashboard/src/lib/dashboard/invoice-view.svelte
+++ b/packages/invoice-dashboard/src/lib/dashboard/invoice-view.svelte
@@ -16,6 +16,7 @@
 
   // Icons
   import Check from "@requestnetwork/shared-icons/check.svelte";
+  import Download from "@requestnetwork/shared-icons/download.svelte";
 
   // Utils
   import { formatDate } from "@requestnetwork/shared-utils/formatDate";
@@ -24,7 +25,7 @@
   // Types
   import type { WalletState } from "@requestnetwork/shared-types/web3Onboard";
 
-  import { walletClientToSigner } from "../../utils";
+  import { walletClientToSigner, exportToPDF } from "../../utils";
   import { formatUnits } from "viem";
   import { onMount } from "svelte";
 
@@ -224,6 +225,7 @@
     <p class={`invoice-status ${isPaid ? "bg-green" : "bg-zinc"}`}>
       {isPaid ? "Paid" : "Created"}
     </p>
+    <Download onClick={() => exportToPDF(request, currency, config.logo)} />
   </h2>
   <div class="invoice-address">
     <h2>From:</h2>
@@ -451,7 +453,13 @@
     line-height: 1.75rem;
     font-weight: 700;
     display: flex;
+    align-items: center;
     gap: 12px;
+  }
+
+  .invoice-number svg {
+    width: 13px;
+    height: 13px;
   }
 
   .invoice-status {

--- a/packages/invoice-dashboard/src/lib/view-requests.svelte
+++ b/packages/invoice-dashboard/src/lib/view-requests.svelte
@@ -16,6 +16,7 @@
   import ChevronLeft from "@requestnetwork/shared-icons/chevron-left.svelte";
   import ChevronRight from "@requestnetwork/shared-icons/chevron-right.svelte";
   import Search from "@requestnetwork/shared-icons/search.svelte";
+  import Download from "@requestnetwork/shared-icons/download.svelte";
 
   // Types
   import type { IConfig } from "@requestnetwork/shared-types";
@@ -30,7 +31,7 @@
   import { Drawer, InvoiceView } from "./dashboard";
   import { Types } from "@requestnetwork/request-client.js";
   import type { RequestNetwork } from "@requestnetwork/request-client.js";
-  import { debounce, formatAddress } from "../utils";
+  import { debounce, exportToPDF, formatAddress } from "../utils";
   import { CurrencyManager } from "@requestnetwork/currency";
 
   export let config: IConfig;
@@ -412,6 +413,7 @@
                   </i>
                 </div>
               </th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -484,6 +486,18 @@
                       ?.symbol}
                   </td>
                   <td> {checkStatus(request)}</td>
+                  <td
+                    ><Download
+                      onClick={() =>
+                        exportToPDF(
+                          request,
+                          currencyManager.fromAddress(
+                            request?.currencyInfo?.value
+                          ),
+                          config.logo
+                        )}
+                    /></td
+                  >
                 </tr>
               {/each}
             {/if}

--- a/packages/invoice-dashboard/src/utils/generateInvoice.ts
+++ b/packages/invoice-dashboard/src/utils/generateInvoice.ts
@@ -1,0 +1,171 @@
+import { formatUnits } from "viem";
+import { loadScript } from "./loadScript";
+import { calculateItemTotal } from "@requestnetwork/shared-utils/invoiceTotals";
+
+declare global {
+  interface Window {
+    html2pdf: any;
+  }
+}
+
+async function ensureHtml2PdfLoaded() {
+  if (typeof window.html2pdf === "undefined") {
+    await loadScript(
+      "https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"
+    );
+  }
+}
+
+export const exportToPDF = async (
+  invoice: any,
+  currency: any,
+  logo: string
+) => {
+  await ensureHtml2PdfLoaded();
+  console.log(invoice);
+
+  const content = `
+    <html>
+    <head>
+      <link rel="preconnect" href="https://fonts.googleapis.com" /> 
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
+    </head>
+    <body>
+    <div id="invoice" style="font-family: Urbanist, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px;">
+      <div style="display: flex; justify-content: space-between; align-items: start;">
+        <img src="${logo}" alt="Logo" style="width: 50px; height: 50px;">
+        <div style="text-align: right;">
+          <p>Issued on ${new Date(
+            invoice.contentData.creationDate
+          ).toLocaleDateString()}</p>
+          <p>Payment due by ${new Date(
+            invoice.contentData.paymentTerms.dueDate
+          ).toLocaleDateString()}</p>
+        </div>
+      </div>
+
+      <h1 style="text-align: center; color: #333; font-size: 28px; font-style: bold; margin-bottom: 14px;">INVOICE #${
+        invoice.contentData.invoiceNumber
+      }</h1>
+
+      <div style="display: flex; justify-content: space-between; margin-bottom: 20px; background-color: #FBFBFB; padding: 10px;">
+        <div>
+          <strong>From:</strong><br>
+          <p style="font-size: 14px">${invoice.payee.value}</p>
+          ${invoice.contentData.sellerInfo.firstName ?? ""} ${
+    invoice.contentData.sellerInfo.lastName ?? ""
+  }<br>
+          ${invoice.contentData.sellerInfo.address["street-address"] ?? ""}<br>
+          ${invoice.contentData.sellerInfo.address.locality ?? ""}${
+    invoice.contentData.sellerInfo.address.locality ? "," : ""
+  } ${invoice.contentData.sellerInfo.address["postal-code"] ?? ""}<br>
+          ${invoice.contentData.sellerInfo.address["country-name"] ?? ""}<br>
+           ${
+             invoice.contentData.sellerInfo.taxRegistration
+               ? `VAT: ${invoice.contentData.sellerInfo.taxRegistration}`
+               : ""
+           }<br>
+        </div>
+
+        <div>
+          <strong>To:</strong><br>
+          <p style="font-size: 14px">${invoice.payer.value}</p>
+          ${invoice.contentData.buyerInfo.firstName ?? ""} ${
+    invoice.contentData.buyerInfo.lastName ?? ""
+  }<br>
+          ${invoice.contentData.buyerInfo.address["street-address"] ?? ""}<br>
+          ${invoice.contentData.buyerInfo.address.locality ?? ""}${
+    invoice.contentData.sellerInfo.address.locality ? "," : ""
+  } ${invoice.contentData.buyerInfo.address["postal-code"] ?? ""}<br>
+          ${invoice.contentData.buyerInfo.address["country-name"] ?? ""}<br>
+           ${
+             invoice.contentData.buyerInfo.taxRegistration
+               ? `VAT: ${invoice.contentData.buyerInfo.taxRegistration}`
+               : ""
+           }<br>
+        </div>
+      </div>
+      
+      <div style="margin-bottom: 20px;">
+        <strong>Payment Chain:</strong> ${invoice.currencyInfo.network}<br>
+        <strong>Invoice Currency:</strong> ${invoice.currency}<br>
+        <strong>Invoice Type:</strong> Regular Invoice
+      </div>
+      
+      <table style="width: 100%; border-collapse: collapse;">
+        <thead>
+          <tr style="background-color: #f2f2f2;">
+            <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">Description</th>
+            <th style="border: 1px solid #ddd; padding: 8px; text-align: right;">Quantity</th>
+            <th style="border: 1px solid #ddd; padding: 8px; text-align: right;">Unit Price</th>
+            <th style="border: 1px solid #ddd; padding: 8px; text-align: right;">Discount</th>
+            <th style="border: 1px solid #ddd; padding: 8px; text-align: right;">Tax</th>
+            <th style="border: 1px solid #ddd; padding: 8px; text-align: right;">Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${invoice.contentData.invoiceItems
+            .map(
+              (item: any) => `
+            <tr>
+              <td style="border: 1px solid #ddd; padding: 8px;">${
+                item.name
+              }</td>
+              <td style="border: 1px solid #ddd; padding: 8px; text-align: right;">${
+                item.quantity
+              }</td>
+              <td style="border: 1px solid #ddd; padding: 8px; text-align: right;">${formatUnits(
+                item.unitPrice,
+                currency.decimals
+              )}</td>
+              <td style="border: 1px solid #ddd; padding: 8px; text-align: right;">${formatUnits(
+                item.discount,
+                currency.decimals
+              )}</td>
+              <td style="border: 1px solid #ddd; padding: 8px; text-align: right;">${
+                item.tax.amount
+              }%</td>
+              <td style="border: 1px solid #ddd; padding: 8px; text-align: right;">${formatUnits(
+                calculateItemTotal(item),
+                currency?.decimals
+              )}</td>
+            </tr>
+          `
+            )
+            .join("")}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="5" style="border: 1px solid #ddd; padding: 8px; text-align: right;"><strong>Due:</strong></td>
+            <td style="border: 1px solid #ddd; padding: 8px; text-align: right;"><strong>${formatUnits(
+              invoice.expectedAmount,
+              currency.decimals
+            )} ${invoice.currency}</strong></td>
+          </tr>
+        </tfoot>
+      </table>
+      
+      ${
+        invoice.contentData.note
+          ? `<div style="margin-top: 20px;">
+        <h3>Memo:</h3>
+        <p>${invoice.contentData.note}</p>
+      </div>`
+          : ""
+      }
+    </div>
+    </body>
+    </html>
+  `;
+
+  const opt = {
+    margin: 10,
+    filename: `invoice-${invoice.contentData.invoiceNumber}.PDF`,
+    image: { type: "jpeg", quality: 0.98 },
+    html2canvas: { scale: 2 },
+    jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+  };
+
+  window.html2pdf().from(content).set(opt).save();
+};

--- a/packages/invoice-dashboard/src/utils/index.ts
+++ b/packages/invoice-dashboard/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { debounce } from "./debounce";
 export { formatAddress } from "./formatAddress";
+export { exportToPDF } from "./generateInvoice";
 export { publicClientToProvider, walletClientToSigner } from "./wallet-utils";

--- a/packages/invoice-dashboard/src/utils/loadScript.ts
+++ b/packages/invoice-dashboard/src/utils/loadScript.ts
@@ -1,0 +1,9 @@
+export const loadScript = (src: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = src;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
+    document.head.appendChild(script);
+  });
+};

--- a/shared/icons/download.svelte
+++ b/shared/icons/download.svelte
@@ -1,0 +1,28 @@
+<script>
+  export let onClick = () => {};
+</script>
+
+<svg
+  width="20px"
+  height="20px"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  on:click|stopPropagation={onClick}
+  ><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g
+    id="SVGRepo_tracerCarrier"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  ></g><g id="SVGRepo_iconCarrier">
+    <g id="Interface / Download">
+      <path
+        id="Vector"
+        d="M6 21H18M12 3V17M12 17L17 12M12 17L7 12"
+        stroke="#000000"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      ></path>
+    </g>
+  </g></svg
+>


### PR DESCRIPTION
### Feature
User can download their invoice from the dashboard and invoice-view

### Downloading
From dashboard:
![Screenshot 2024-07-18 at 14 06 11](https://github.com/user-attachments/assets/094b0751-7641-4584-8a6a-436799c8dcfa)

From invoice-view:
![Screenshot 2024-07-18 at 14 06 34](https://github.com/user-attachments/assets/c7bba8ba-c04b-40ec-b217-a97729099316)


### Solution
- added `html2pdf.js` through CDN (Vite had problems with every PDF package)
- added download button on dashboard and invoice-view
- added invoice format on download

### Downloaded Invoices (with and without more information)
[invoice-1.PDF](https://github.com/user-attachments/files/16282948/invoice-1.PDF)

[invoice-1 (1).PDF](https://github.com/user-attachments/files/16282950/invoice-1.1.PDF)
