### PR TITLE
fix: error message check for polling

### DIFF
--- a/packages/create-invoice-form/src/lib/create-invoice-form.svelte
+++ b/packages/create-invoice-form/src/lib/create-invoice-form.svelte
@@ -228,7 +228,6 @@
         type="button"
         onClick={async () => {
           isTimeout = false;
-          console.log(activeRequest);
           addToStatus(APP_STATUS.PERSISTING_TO_IPFS);
           addToStatus(APP_STATUS.PERSISTING_ON_CHAIN);
           await activeRequest.waitForConfirmation();

--- a/packages/create-invoice-form/src/lib/create-invoice-form.svelte
+++ b/packages/create-invoice-form/src/lib/create-invoice-form.svelte
@@ -151,7 +151,7 @@
         await request.waitForConfirmation();
         addToStatus(APP_STATUS.REQUEST_CONFIRMED);
       } catch (error: any) {
-        if (error.message.includes("timeout")) {
+        if (error.message.includes("Transactioon confirmation not received")) {
           isTimeout = true;
           removeAllStatuses();
         } else {
@@ -228,6 +228,7 @@
         type="button"
         onClick={async () => {
           isTimeout = false;
+          console.log(activeRequest);
           addToStatus(APP_STATUS.PERSISTING_TO_IPFS);
           addToStatus(APP_STATUS.PERSISTING_ON_CHAIN);
           await activeRequest.waitForConfirmation();


### PR DESCRIPTION
- changed the message in the if statement in the catch block

## Testing

I tested by throwing an Error, couldn't reproduce it, I did it like this
<img width="798" alt="Screenshot 2024-07-24 at 14 37 14" src="https://github.com/user-attachments/assets/ac188fda-a0c1-4339-9d48-1a3d2a32e6fc">

And this is how the modal looks:
![Screenshot 2024-07-24 at 14 37 32](https://github.com/user-attachments/assets/0a1d9e1f-254d-439c-b36d-03fb82ecf895)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the invoice creation process to provide more accurate feedback for transaction confirmation issues. Users will now receive specific notifications if a transaction confirmation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->