### PR TITLE
fix: package-lock.json out-of-date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14279,7 +14279,7 @@
     },
     "packages/invoice-dashboard": {
       "name": "@requestnetwork/invoice-dashboard",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/payment-detection": "0.43.1-next.2043",
@@ -14302,7 +14302,7 @@
     },
     "packages/payment-widget": {
       "name": "@requestnetwork/payment-widget",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/payment-processor": "^0.47.0",


### PR DESCRIPTION
# Problem

Package lock was out of date - had old versions for invoice-dashboard and payment-widget

# Solution

Run `npm install` at the root