### PR TITLE
feat: add billing information support

### DIFF
--- a/packages/payment-widget/src/lib/components/buyer-info-form.svelte
+++ b/packages/payment-widget/src/lib/components/buyer-info-form.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+  import type { BuyerInfo, PaymentStep } from "../types";
+
+  export let currentPaymentStep: PaymentStep;
+
+  export let buyerInfo: BuyerInfo;
+
+  let errors: Partial<Record<keyof BuyerInfo, string>> = {};
+
+  function validateEmail(email: string): boolean {
+    const re = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+    return re.test(email);
+  }
+
+  function validateForm(): boolean {
+    errors = {};
+    let isValid = true;
+
+    if (!buyerInfo.email || !validateEmail(buyerInfo.email)) {
+      errors.email = "Please enter a valid email address";
+      isValid = false;
+    }
+
+    if (!buyerInfo.firstName) {
+      errors.firstName = "First name is required";
+      isValid = false;
+    }
+
+    if (!buyerInfo.lastName) {
+      errors.lastName = "Last name is required";
+      isValid = false;
+    }
+
+    if (buyerInfo.phone && !/^\+?[1-9]\d{1,14}$/.test(buyerInfo.phone)) {
+      errors.phone = "Please enter a valid phone number";
+      isValid = false;
+    }
+
+    return isValid;
+  }
+
+  $: {
+    buyerInfo = buyerInfo || {};
+    buyerInfo.address = buyerInfo.address || {};
+  }
+</script>
+
+<div class="buyer-info-form">
+  <h3>Buyer Information</h3>
+  <form>
+    <div class="form-group">
+      <label for="email">Email</label>
+      <input
+        type="email"
+        id="email"
+        bind:value={buyerInfo.email}
+        required
+        placeholder="john.doe@example.com"
+      />
+      {#if errors.email}<span class="error">{errors.email}</span>{/if}
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label for="firstName">First Name</label>
+        <input
+          type="text"
+          id="firstName"
+          bind:value={buyerInfo.firstName}
+          required
+          placeholder="John"
+        />
+        {#if errors.firstName}<span class="error">{errors.firstName}</span>{/if}
+      </div>
+      <div class="form-group">
+        <label for="lastName">Last Name</label>
+        <input
+          type="text"
+          id="lastName"
+          bind:value={buyerInfo.lastName}
+          required
+          placeholder="Doe"
+        />
+        {#if errors.lastName}<span class="error">{errors.lastName}</span>{/if}
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label for="businessName">Business Name</label>
+        <input
+          type="text"
+          id="businessName"
+          bind:value={buyerInfo.businessName}
+          placeholder="Acme Inc."
+        />
+      </div>
+      <div class="form-group">
+        <label for="phone">Phone</label>
+        <input
+          type="tel"
+          id="phone"
+          bind:value={buyerInfo.phone}
+          placeholder="+1 (555) 123-4567"
+        />
+        {#if errors.phone}<span class="error">{errors.phone}</span>{/if}
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="street-address">Street Address</label>
+      <input
+        type="text"
+        id="street-address"
+        bind:value={buyerInfo.address["street-address"]}
+        placeholder="123 Main St, Apt 4B"
+      />
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label for="locality">City</label>
+        <input
+          type="text"
+          id="locality"
+          bind:value={buyerInfo.address.locality}
+          placeholder="San Francisco"
+        />
+      </div>
+      <div class="form-group">
+        <label for="region">State/Province</label>
+        <input
+          type="text"
+          id="region"
+          bind:value={buyerInfo.address.region}
+          placeholder="CA"
+        />
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label for="country-name">Country</label>
+        <input
+          type="text"
+          id="country-name"
+          bind:value={buyerInfo.address["country-name"]}
+          placeholder="United States"
+        />
+      </div>
+      <div class="form-group">
+        <label for="postal-code">Postal Code</label>
+        <input
+          type="text"
+          id="postal-code"
+          bind:value={buyerInfo.address["postal-code"]}
+          placeholder="94105"
+        />
+      </div>
+    </div>
+    <div class="button-group">
+      <button
+        class="btn btn-secondary"
+        type="button"
+        on:click={() => {
+          currentPaymentStep = "currency";
+        }}>Back</button
+      >
+      <button
+        type="button"
+        on:click={() => {
+          if (validateForm()) {
+            currentPaymentStep = "confirmation";
+          }
+        }}
+        class="btn">Continue to Payment</button
+      >
+    </div>
+  </form>
+</div>
+
+<style lang="scss">
+  @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700;800;900&display=swap");
+
+  .buyer-info-form {
+    font-family: "Montserrat", sans-serif;
+    color: #333;
+    max-height: 100%;
+    padding: 1rem;
+    max-width: 90%;
+
+    h3 {
+      margin: 0 0 1rem;
+      font-size: 18px;
+      font-weight: bold;
+    }
+
+    form {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .form-row {
+      display: flex;
+      gap: 8px;
+
+      input {
+        width: 90% !important;
+      }
+    }
+
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      gap: 0.5rem;
+    }
+
+    label {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    input {
+      width: 100%;
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 14px;
+      font-family: inherit;
+
+      &:focus {
+        outline: none;
+        border-color: #0bb489;
+      }
+    }
+
+    .error {
+      color: #ff4136;
+      font-size: 12px;
+    }
+
+    .button-group {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      margin-top: 1rem;
+    }
+
+    .btn {
+      display: inline-flex;
+      cursor: pointer;
+      color: white;
+      align-items: center;
+      justify-content: center;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      background-color: #0bb489;
+      border: none;
+      outline: none;
+      width: 100%;
+      padding: 8px 16px;
+      gap: 8px;
+
+      &:hover {
+        background-color: darken(#0bb489, 10%);
+      }
+
+      &:disabled {
+        background-color: #cccccc;
+        cursor: not-allowed;
+      }
+    }
+
+    .btn-secondary {
+      background-color: #666;
+
+      &:hover {
+        background-color: rgba($color: #666, $alpha: 0.8);
+      }
+    }
+  }
+</style>

--- a/packages/payment-widget/src/lib/components/currency-selector.svelte
+++ b/packages/payment-widget/src/lib/components/currency-selector.svelte
@@ -6,13 +6,12 @@
 
   export let currencies: Currency[];
   export let selectedCurrency: Currency | null = null;
-  export let currentPaymentStep: PaymentStep;
   export let web3Modal: Web3Modal | null;
   export let isConnected: boolean;
+  export let onCurrencySelected: () => void;
 
   function selectCurrency(currency: Currency) {
     selectedCurrency = currency;
-    currentPaymentStep = "confirmation";
   }
 </script>
 
@@ -43,16 +42,20 @@
       </button>
     {/each}
   </div>
+  <button
+    class="btn"
+    disabled={!selectedCurrency}
+    on:click={onCurrencySelected}
+  >
+    Next
+  </button>
 </div>
 
 <style lang="scss">
   @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700;800;900&display=swap");
 
-  body {
-    font-family: "Montserrat", sans-serif;
-  }
-
   .currency-selector {
+    font-family: "Montserrat", sans-serif;
     width: 100%;
     color: #333;
 
@@ -65,6 +68,7 @@
     .currency-list {
       max-height: 300px;
       overflow-y: auto;
+      margin-bottom: 20px;
 
       &::-webkit-scrollbar {
         width: 6px;
@@ -135,6 +139,32 @@
         font-size: 14px;
         color: #666;
       }
+    }
+  }
+
+  .btn {
+    display: inline-flex;
+    cursor: pointer;
+    color: white;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    background-color: #0bb489;
+    border: none;
+    outline: none;
+    width: 100%;
+    padding: 8px 16px;
+    gap: 8px;
+
+    &:hover:not(:disabled) {
+      background-color: darken(#0bb489, 10%);
+    }
+
+    &:disabled {
+      background-color: #cccccc;
+      cursor: not-allowed;
     }
   }
 </style>

--- a/packages/payment-widget/src/lib/components/payment-confirmation.svelte
+++ b/packages/payment-widget/src/lib/components/payment-confirmation.svelte
@@ -5,7 +5,13 @@
   import InfoCircleIcon from "@requestnetwork/shared-icons/info-circle.svelte";
   import type { Web3Modal } from "@web3modal/ethers5";
   import { onDestroy, onMount } from "svelte";
-  import type { Currency, PaymentStep } from "../types";
+  import type {
+    Currency,
+    PaymentStep,
+    SellerInfo,
+    BuyerInfo,
+    ProductInfo,
+  } from "../types";
   import { chains } from "../utils/chains";
   import { NETWORK_LABEL } from "../utils/currencies";
   import {
@@ -17,16 +23,20 @@
 
   export let selectedCurrency: Currency;
   export let amountInUSD: number;
-  export let sellerName: string | undefined;
-  export let productName: string | undefined;
+  export let sellerInfo: SellerInfo;
+  export let buyerInfo: BuyerInfo;
+  export let productInfo: ProductInfo | undefined;
   export let sellerAddress: string;
   export let currentPaymentStep: PaymentStep;
   export let web3Modal: Web3Modal | null;
   export let isConnected: boolean;
   export let builderId: string;
   export let persistRequest: boolean;
+  export let enableBuyerInfo: boolean;
   export let onPaymentSuccess: (request: any) => void;
   export let onPaymentError: (error: string) => void;
+  export let invoiceNumber: string | undefined;
+
   const COUNTDOWN_INTERVAL = 30;
 
   let amountInCrypto: number = 0;
@@ -182,7 +192,11 @@
   <div class="button-group">
     <button
       on:click={() => {
-        currentPaymentStep = "currency";
+        if (enableBuyerInfo) {
+          currentPaymentStep = "buyer-info";
+        } else {
+          currentPaymentStep = "currency";
+        }
       }}
       disabled={isPaying}
       class="btn btn-secondary">Back</button
@@ -202,15 +216,17 @@
         try {
           const requestParameters = prepareRequestParameters({
             currency: selectedCurrency,
-            productName,
-            sellerName,
-            sellerAddress,
+            productInfo,
+            sellerInfo,
+            buyerInfo,
             payerAddress,
             amountInCrypto,
             exchangeRate,
             amountInUSD,
             builderId,
             createdWith: window.location.hostname,
+            invoiceNumber,
+            sellerAddress,
           });
 
           const request = await handleRequestPayment({

--- a/packages/payment-widget/src/lib/react/PaymentWidget.d.ts
+++ b/packages/payment-widget/src/lib/react/PaymentWidget.d.ts
@@ -4,6 +4,7 @@ import type {
   ProductInfo,
   AmountInUSD,
   SupportedCurrencies,
+  BuyerInfo,
 } from "../types";
 
 export interface PaymentWidgetProps {
@@ -17,6 +18,9 @@ export interface PaymentWidgetProps {
   builderId?: string;
   onPaymentSuccess?: (request: any) => void;
   onError?: (error: string) => void;
+  buyerInfo?: BuyerInfo;
+  enableBuyerInfo?: boolean;
+  invoiceNumber?: string;
 }
 
 /**
@@ -30,6 +34,7 @@ export interface PaymentWidgetProps {
  * - Supports multiple cryptocurrencies
  * - Handles transaction creation and management
  * - Provides real-time payment status updates
+ * - Supports full invoice information
  *
  * @param {PaymentWidgetProps} props - The component props
  * @returns {JSX.Element}
@@ -38,7 +43,15 @@ export interface PaymentWidgetProps {
  * <PaymentWidget
  *   sellerInfo={{
  *     logo: 'https://example.com/logo.png',
- *     name: 'Example Store'
+ *     name: 'Example Store',
+ *     email: 'store@example.com',
+ *     address: {
+ *       'street-address': '123 Main St',
+ *       locality: 'Anytown',
+ *       region: 'State',
+ *       'country-name': 'Country',
+ *       'postal-code': '12345'
+ *     }
  *   }}
  *   productInfo={{
  *     name: 'Digital Art Collection',
@@ -49,6 +62,8 @@ export interface PaymentWidgetProps {
  *   sellerAddress="0x1234567890123456789012345678901234567890"
  *   supportedCurrencies={['ETH_MAINNET', 'USDC_MAINNET', 'USDC_MATIC']}
  *   persistRequest={true}
+ *   enableBuyerInfo={true}
+ *   invoiceNumber="INV-001"
  *   onPaymentSuccess={(request) => {
  *     console.log(request);
  *   }}

--- a/packages/payment-widget/src/lib/types/index.ts
+++ b/packages/payment-widget/src/lib/types/index.ts
@@ -1,9 +1,36 @@
 import type { CURRENCY_ID, NETWORK_LABEL } from "../utils/currencies";
 
-export type SellerInfo = {
+export interface Address {
+  "street-address"?: string;
+  locality?: string;
+  region?: string;
+  "country-name"?: string;
+  "postal-code"?: string;
+}
+
+export interface SellerInfo {
   logo?: string;
   name?: string;
-};
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  businessName?: string;
+  phone?: string;
+  address?: Address;
+  taxRegistration?: string;
+  companyRegistration?: string;
+}
+
+export interface BuyerInfo {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  businessName?: string;
+  phone?: string;
+  address?: Address;
+  taxRegistration?: string;
+  companyRegistration?: string;
+}
 
 export type ProductInfo = {
   name?: string;
@@ -27,4 +54,8 @@ export type Currency = {
   name?: string;
 };
 
-export type PaymentStep = "currency" | "confirmation" | "complete";
+export type PaymentStep =
+  | "currency"
+  | "buyer-info"
+  | "confirmation"
+  | "complete";

--- a/packages/payment-widget/src/lib/utils/request.ts
+++ b/packages/payment-widget/src/lib/utils/request.ts
@@ -11,7 +11,7 @@ import {
 } from "@requestnetwork/request-client.js";
 import { Web3SignatureProvider } from "@requestnetwork/web3-signature";
 import { providers, utils } from "ethers";
-import type { Currency } from "../types";
+import type { BuyerInfo, Currency, ProductInfo, SellerInfo } from "../types";
 import { chains } from "./chains";
 
 export const prepareRequestParameters = ({
@@ -23,8 +23,10 @@ export const prepareRequestParameters = ({
   amountInUSD,
   createdWith,
   builderId,
-  productName,
-  sellerName,
+  productInfo,
+  sellerInfo,
+  buyerInfo,
+  invoiceNumber,
 }: {
   currency: Currency;
   sellerAddress: string;
@@ -34,14 +36,17 @@ export const prepareRequestParameters = ({
   amountInUSD: number;
   builderId: string;
   createdWith: string;
-  productName: string | undefined;
-  sellerName: string | undefined;
+  productInfo: ProductInfo | undefined;
+  sellerInfo: SellerInfo;
+  buyerInfo: BuyerInfo;
+  invoiceNumber?: string;
 }) => {
   const isERC20 = currency.type === Types.RequestLogic.CURRENCY.ERC20;
   const currencyValue = isERC20 ? currency.address : "eth";
   const amount = utils
     .parseUnits(amountInCrypto.toFixed(currency.decimals), currency.decimals)
     .toString();
+
   return {
     requestInfo: {
       currency: {
@@ -69,7 +74,6 @@ export const prepareRequestParameters = ({
         paymentAddress: sellerAddress,
         feeAddress: "0x0000000000000000000000000000000000000000",
         feeAmount: "0",
-        tokenAddress: currencyValue,
       },
     },
     contentData: {
@@ -78,11 +82,42 @@ export const prepareRequestParameters = ({
         version: "0.0.3",
       },
       creationDate: new Date().toISOString(),
-      invoiceNumber: "rn-checkout",
-      note: `Sale made with ${currency.symbol} on ${currency.network} for amount of ${amountInUSD} USD with an exchange rate of ${exchangeRate}`,
+      invoiceNumber: invoiceNumber || "receipt",
+      sellerInfo: {
+        email: sellerInfo?.email || undefined,
+        firstName: sellerInfo?.firstName || undefined,
+        lastName: sellerInfo?.lastName || undefined,
+        businessName: sellerInfo?.businessName || undefined,
+        phone: sellerInfo?.phone || undefined,
+        address: sellerInfo?.address
+          ? {
+              streetAddress: sellerInfo.address["street-address"] || undefined,
+              locality: sellerInfo.address.locality || undefined,
+              postalCode: sellerInfo.address["postal-code"] || undefined,
+              country: sellerInfo.address["country-name"] || undefined,
+            }
+          : undefined,
+        taxRegistration: sellerInfo?.taxRegistration || undefined,
+      },
+      buyerInfo: {
+        email: buyerInfo?.email || undefined,
+        firstName: buyerInfo?.firstName || undefined,
+        lastName: buyerInfo?.lastName || undefined,
+        businessName: buyerInfo?.businessName || undefined,
+        phone: buyerInfo?.phone || undefined,
+        address: buyerInfo?.address
+          ? {
+              streetAddress: buyerInfo.address["street-address"] || undefined,
+              locality: buyerInfo.address.locality || undefined,
+              postalCode: buyerInfo.address["postal-code"] || undefined,
+              country: buyerInfo.address["country-name"] || undefined,
+            }
+          : undefined,
+        taxRegistration: buyerInfo?.taxRegistration || undefined,
+      },
       invoiceItems: [
         {
-          name: productName || "",
+          name: productInfo?.name || "Unnamed product",
           quantity: 1,
           unitPrice: amount,
           discount: "0",
@@ -93,12 +128,8 @@ export const prepareRequestParameters = ({
           currency: isERC20 ? currency.address : currency.symbol,
         },
       ],
-
       paymentTerms: {
         dueDate: new Date().toISOString(),
-      },
-      sellerInfo: {
-        businessName: sellerName || undefined,
       },
       miscellaneous: {
         exchangeRate: exchangeRate.toString(),

--- a/packages/payment-widget/src/lib/utils/request.ts
+++ b/packages/payment-widget/src/lib/utils/request.ts
@@ -83,6 +83,7 @@ export const prepareRequestParameters = ({
       },
       creationDate: new Date().toISOString(),
       invoiceNumber: invoiceNumber || "receipt",
+      note: `Sale made with ${currency.symbol} on ${currency.network} for amount of ${amountInUSD} USD with an exchange rate of ${exchangeRate}`,
       sellerInfo: {
         email: sellerInfo?.email || undefined,
         firstName: sellerInfo?.firstName || undefined,


### PR DESCRIPTION
Resolves #107 
Resolves #110 

- Adds props for `sellerInfo`, `buyerInfo`, `invoiceNumber` , and `enableBuyerInfo`
- Shows a new step for buyer to fill in their billing information if `enableBuyerInfo` is set to true (default to true)
- Skips the billing information step if `enableBuyerInfo` is set to false
- Follows the invoice format

![CleanShot 2024-09-03 at 22 52 14](https://github.com/user-attachments/assets/3f59d227-e53f-4292-b0ff-5cd98b17feb9)


![CleanShot 2024-09-03 at 22 51 11](https://github.com/user-attachments/assets/35d244e4-7427-48e5-8c65-de9e761c8865)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a buyer information form for collecting essential buyer details within the payment widget.
	- Enhanced the currency selector with improved user interaction and modularity.
	- Updated payment confirmation to handle detailed seller, buyer, and product information.
	- Added support for dynamic payment steps based on buyer information presence.

- **Bug Fixes**
	- Improved validation logic for buyer information to ensure data integrity before proceeding.

- **Documentation**
	- Updated type definitions and interface documentation to reflect new properties and structures for better clarity.

- **Chores**
	- Refined internal request handling to accommodate new data structures for improved transaction management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->