### PR TITLE
fix: npm token env var

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,3 +1,5 @@
+# @format
+
 name: release-if-necessary
 
 on:
@@ -12,9 +14,9 @@ jobs:
     strategy:
       matrix:
         package:
-          - "@requestnetwork/add-stakeholder"
-          - "@requestnetwork/create-invoice-form"
-          - "@requestnetwork/invoice-dashboard"
+          - '@requestnetwork/add-stakeholder'
+          - '@requestnetwork/create-invoice-form'
+          - '@requestnetwork/invoice-dashboard'
     steps:
       - name: Checkout repository 🛎️
         uses: actions/checkout@v4
@@ -22,8 +24,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
-          registry-url: "https://registry.npmjs.org"
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies 📥
         run: npm ci
@@ -39,14 +41,9 @@ jobs:
           echo "is-release-needed=$IS_RELEASE_NEEDED"
           echo "is-release-needed=$IS_RELEASE_NEEDED" >> $GITHUB_OUTPUT
 
-      - name: Setup .npmrc file to publish to npm 📝
-        if: steps.is-release-needed.outputs.is-release-needed == 'true'
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.REQUEST_BOT_NPM_TOKEN }}" > ~/.npmrc
-
       - name: Publish package on NPM 📦
         if: steps.is-release-needed.outputs.is-release-needed == 'true'
         run: |
-          npm config set registry https://registry.npmjs.org
-          npm whoami || { echo "Failed to identify npm user."; exit 1; }
-          npm config get registry || { echo "Failed to get npm registry."; exit 1; }
           npm publish --workspace=${{ matrix.package }} --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.REQUEST_BOT_NPM_TOKEN }}


### PR DESCRIPTION
Fixes #29

Changes:
- Change the way the npm token is set based on this [documentation](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified authentication process for npm publishing by using an environment variable instead of a configuration file.
  
- **Bug Fixes**
	- Enhanced security by eliminating the creation of a potentially sensitive `.npmrc` file.

- **Refactor**
	- Standardized string formatting for improved consistency and readability in the workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->