### PR TITLE
On changing network, causes to the dashboard to refetch data

### DIFF
--- a/packages/invoice-dashboard/src/lib/view-requests.svelte
+++ b/packages/invoice-dashboard/src/lib/view-requests.svelte
@@ -142,14 +142,14 @@
     ) {
       getRequests();
       previousWalletAddress = currentWalletAddress;
+
+      activeRequest = undefined;
     }
 
     if (currentNetwork && currentNetwork !== previousNetwork) {
       previousNetwork = currentNetwork;
     }
   }
-
-  $: wallet, (activeRequest = undefined);
 
   $: {
     if (sortColumn && sortOrder) {

--- a/packages/invoice-dashboard/src/lib/view-requests.svelte
+++ b/packages/invoice-dashboard/src/lib/view-requests.svelte
@@ -85,8 +85,8 @@
 
   const getRequests = async () => {
     if (!wallet || !requestNetwork) return;
-
     loading = true;
+
     try {
       const requestsData = await requestNetwork?.fromIdentity({
         type: Types.Identity.TYPE.ETHEREUM_ADDRESS,
@@ -103,9 +103,10 @@
   };
 
   const getOneRequest = async (activeRequest: any) => {
+    if (!activeRequest) return;
+    loading = true;
+
     try {
-      if (!activeRequest) return;
-      loading = true;
       const _request = await requestNetwork?.fromRequestId(
         activeRequest?.requestId!
       );

--- a/packages/invoice-dashboard/src/types/global.d.ts
+++ b/packages/invoice-dashboard/src/types/global.d.ts
@@ -1,5 +1,11 @@
 declare interface Window {
   ethereum: {
+    on: (event: string, callback: (accounts: string[]) => void) => void;
+    removeListener: (
+      event: string,
+      callback: (accounts: string[]) => void
+    ) => void;
     request: (request: { method: string }) => Promise<void>;
+    autoRefreshOnNetworkChange: boolean;
   };
 }

--- a/shared/components/button/button.svelte
+++ b/shared/components/button/button.svelte
@@ -8,8 +8,17 @@
   let className: $$Props["class"] = undefined;
   export let builders: $$Props["builders"] = [];
   export { className as class };
+  export let onClick: (event: MouseEvent) => void = () => {};
+  export let preventDefault: boolean = true;
 
   $: classes = ["rn-btn", className].filter(Boolean).join(" ");
+
+  function handleClick(event: MouseEvent) {
+    if (preventDefault) {
+      event.preventDefault();
+    }
+    onClick(event);
+  }
 </script>
 
 <ButtonPrimitive.Root
@@ -17,7 +26,7 @@
   class={classes}
   type="button"
   {...$$restProps}
-  on:click
+  on:click={handleClick}
   on:keydown
 >
   <slot />


### PR DESCRIPTION
Fixes #95 

### Problem

When someone tries to use the button Switch Network or even switch network from their wallet, that triggers a refetch of the whole table and gives impression of page reloading

### Solution

- Checking if the actuall address changed solved this, now we only refetch when the network changes
- Added `preventDefault` to the button just in case
- Added `window.ethereum` functions to the types file
- Signle invoice now closes only on wallet account change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced wallet address and network handling for improved request fetching.
	- Added event handling methods for Ethereum functionality in the interface.
	- Introduced customizable click handling in button components.

- **Bug Fixes**
	- Streamlined error handling and loading state management in request fetching.

- **Documentation**
	- Updated interface definitions for better clarity on new properties and methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->