### PR TITLE
fix: Add link:react script that links react and react-dom from the app into the web-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,18 @@ npm install
 # Build all packages locally
 npm run build
 
-# Link packages to be used locally
-npm run link:all
+# Link local web-component packages into your app
+npm run link:all --app-path=/path/to/app
+## Examples
+npm run link:all --app-path=../invoicing-template
+npm run link:all --app-path=../rn-checkout
 
 # Navigate to your project directory where the web components are used
 cd <project>
 
 # Use local packages instead of the deployed ones
 npm link @requestnetwork/create-invoice-form @requestnetwork/invoice-dashboard
+npm link @requestnetwork/payment-widget
 ```
 
 Further details specific to the component can be found in the relevant

--- a/package-lock.json
+++ b/package-lock.json
@@ -14273,7 +14273,7 @@
     },
     "packages/create-invoice-form": {
       "name": "@requestnetwork/create-invoice-form",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/request-client.js": "0.47.1-next.2043",
@@ -14289,7 +14289,7 @@
     },
     "packages/invoice-dashboard": {
       "name": "@requestnetwork/invoice-dashboard",
-      "version": "0.6.1",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/payment-detection": "0.43.1-next.2043",
@@ -14321,7 +14321,7 @@
     },
     "packages/payment-widget": {
       "name": "@requestnetwork/payment-widget",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/payment-processor": "^0.47.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "build:dashboard": "turbo run build --filter=@requestnetwork/invoice-dashboard",
     "build:stakeholder": "turbo run build --filter=@requestnetwork/add-stakeholder",
     "build:payment-widget": "turbo run build --filter=@requestnetwork/payment-widget",
-    "link:react": "npm link ../invoicing-template/node_modules/react ../invoicing-template/node_modules/react-dom",
-    "link:all": "npm run link:react && for d in packages/*; do (cd $d && npm link); done",
+    "echo": "echo $npm_config_app_path/node_modules/react",
+    "link:react": "npm link $npm_config_app_path/node_modules/react $npm_config_app_path/node_modules/react-dom",
+    "link:all": "npm run link:react --app-path=$npm_config_app_path && for d in packages/*; do (cd $d && npm link); done",
     "unlink:all": "for d in packages/*; do (cd $d && npm unlink); done"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "build:dashboard": "turbo run build --filter=@requestnetwork/invoice-dashboard",
     "build:stakeholder": "turbo run build --filter=@requestnetwork/add-stakeholder",
     "build:payment-widget": "turbo run build --filter=@requestnetwork/payment-widget",
-    "echo": "echo $npm_config_app_path/node_modules/react",
     "link:react": "npm link $npm_config_app_path/node_modules/react $npm_config_app_path/node_modules/react-dom",
     "link:all": "npm run link:react --app-path=$npm_config_app_path && for d in packages/*; do (cd $d && npm link); done",
     "unlink:all": "for d in packages/*; do (cd $d && npm unlink); done"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build:dashboard": "turbo run build --filter=@requestnetwork/invoice-dashboard",
     "build:stakeholder": "turbo run build --filter=@requestnetwork/add-stakeholder",
     "build:payment-widget": "turbo run build --filter=@requestnetwork/payment-widget",
-    "link:all": "for d in packages/*; do (cd $d && npm link); done",
+    "link:react": "npm link ../invoicing-template/node_modules/react ../invoicing-template/node_modules/react-dom",
+    "link:all": "npm run link:react && for d in packages/*; do (cd $d && npm link); done",
     "unlink:all": "for d in packages/*; do (cd $d && npm unlink); done"
   },
   "devDependencies": {


### PR DESCRIPTION
# Problem

Running the invoicing-template often fails when using local linked web-component packages. It throws the error shown below:
![image](https://github.com/user-attachments/assets/4fa64892-e3ca-4647-9376-4af9ede3632b)

# Solution

It is an issue with react and react-dom version conflicts. The fix is to run the following command in the web-component repo.

```console
npm link ../invoicing-template/node_modules/react ../invoicing-template/node_modules/react-dom
```

Reference: https://iws.io/2022/invalid-hook-multiple-react-instances

# Changes

* Add `link:react` script that takes an `--app-path` argument that links the react and react-dom from the app into the web-component
* Updated `link:all` to call `link:react` so now `link:all` also requires the `-app-path` argument.
* Sync package-lock.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced README with clearer instructions for linking local web-component packages.
	- Introduced a new npm script `link:react` for targeted linking of React and React DOM modules.

- **Documentation**
	- Added examples for using the `--app-path` option in the linking instructions.
	- Included command for linking the `@requestnetwork/payment-widget` package. 

- **Workflow Improvements**
	- Updated the `link:all` script to ensure React dependencies are linked before other packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->