### PR TITLE
feat: enable custom fee address and fee amount

### DIFF
--- a/packages/payment-widget/src/lib/components/payment-confirmation.svelte
+++ b/packages/payment-widget/src/lib/components/payment-confirmation.svelte
@@ -151,38 +151,42 @@
       >
     </div>
   </div>
-  <div class="payment-confirmation-tab payment-confirmation-seller-address">
+  <div class="payment-confirmation-tab payment-confirmation-address">
     <h4>Payment to</h4>
-    <a
-      href={getExplorerUrl(selectedCurrency.network, sellerAddress)}
-      target="_blank"
-    >
-      <span>{sellerAddress}</span>
-    </a>
-    <button
-      on:click={() => {
-        navigator.clipboard.writeText(sellerAddress);
-      }}
-    >
-      <CopyIcon />
-    </button>
-  </div>
-  {#if feeAddress !== ethers.constants.AddressZero && feeAmountInUSD > 0}
-    <div class="payment-confirmation-tab">
-      <h4>Fee to</h4>
+    <div class="address-container">
       <a
-        href={getExplorerUrl(selectedCurrency.network, feeAddress)}
+        href={getExplorerUrl(selectedCurrency.network, sellerAddress)}
         target="_blank"
       >
-        <span>{feeAddress}</span>
+        <span>{sellerAddress}</span>
       </a>
       <button
         on:click={() => {
-          navigator.clipboard.writeText(feeAddress);
+          navigator.clipboard.writeText(sellerAddress);
         }}
       >
         <CopyIcon />
       </button>
+    </div>
+  </div>
+  {#if feeAddress !== ethers.constants.AddressZero && feeAmountInUSD > 0}
+    <div class="payment-confirmation-tab payment-confirmation-address">
+      <h4>Fee to</h4>
+      <div class="address-container">
+        <a
+          href={getExplorerUrl(selectedCurrency.network, feeAddress)}
+          target="_blank"
+        >
+          <span>{feeAddress}</span>
+        </a>
+        <button
+          on:click={() => {
+            navigator.clipboard.writeText(feeAddress);
+          }}
+        >
+          <CopyIcon />
+        </button>
+      </div>
     </div>
     <div class="payment-confirmation-tab">
       <h4>Fee Amount</h4>
@@ -254,7 +258,8 @@
             sellerInfo,
             buyerInfo,
             payerAddress,
-            amountInCrypto: totalPayment,
+            amountInCrypto,
+            totalAmountInCrypto: totalPayment,
             exchangeRate,
             amountInUSD,
             builderId,
@@ -320,23 +325,6 @@
     width: 100%;
     gap: 16px;
 
-    .payment-confirmation-seller-address {
-      display: flex;
-      align-items: center;
-      gap: 2px;
-      font-size: 12px;
-
-      button {
-        background: none;
-        border: none;
-        padding: 0;
-        margin: 0;
-        cursor: pointer;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-      }
-    }
     &-amount-info {
       display: flex;
       align-items: center;
@@ -384,6 +372,49 @@
         color: black;
         font-weight: 500;
         font-size: 14px;
+      }
+
+      &.payment-confirmation-address {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+
+        h4 {
+          margin: 0;
+        }
+
+        .address-container {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          width: 100%;
+
+          a {
+            flex-grow: 1;
+            text-decoration: none;
+            color: inherit;
+            font-size: 14px;
+
+            span {
+              display: inline-block;
+              width: 100%;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+          }
+
+          button {
+            background: none;
+            border: none;
+            padding: 0;
+            margin: 0;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          }
+        }
       }
     }
 

--- a/packages/payment-widget/src/lib/payment-widget.svelte
+++ b/packages/payment-widget/src/lib/payment-widget.svelte
@@ -1,15 +1,16 @@
 <svelte:options customElement="payment-widget" />
 
 <script lang="ts">
-  import { Button } from "@requestnetwork/shared-components/button";
   import Modal from "@requestnetwork/shared-components/modal.svelte";
+  import PoweredBy from "@requestnetwork/shared-components/powered-by.svelte";
   import type { EventsControllerState } from "@web3modal/core";
   import type { Web3Modal } from "@web3modal/ethers5";
+  import { ethers } from "ethers";
   import { onDestroy, onMount } from "svelte";
+  import BuyerInfoForm from "./components/buyer-info-form.svelte";
   import CurrencySelector from "./components/currency-selector.svelte";
   import PaymentComplete from "./components/payment-complete.svelte";
   import PaymentConfirmation from "./components/payment-confirmation.svelte";
-  import PoweredBy from "@requestnetwork/shared-components/powered-by.svelte";
   import type {
     AmountInUSD,
     BuyerInfo,
@@ -21,8 +22,6 @@
   } from "./types";
   import { getSupportedCurrencies } from "./utils/currencies";
   import { initWalletConnector } from "./utils/walletConnector";
-  import BuyerInfoForm from "./components/buyer-info-form.svelte";
-  import { ethers } from "ethers";
 
   // Props
   export let sellerInfo: SellerInfo;

--- a/packages/payment-widget/src/lib/payment-widget.svelte
+++ b/packages/payment-widget/src/lib/payment-widget.svelte
@@ -196,7 +196,7 @@
 
   <section class="rn-payment-widget-body">
     <h2>Pay with crypto</h2>
-    <Button
+    <button
       disabled={!amountInUSD ||
         !sellerAddress ||
         amountInUSD === 0 ||
@@ -207,7 +207,7 @@
         } else {
           isModalOpen = true;
         }
-      }}>Pay</Button
+      }}>Pay</button
     >
   </section>
   <Modal
@@ -371,6 +371,41 @@
       margin: 0;
       height: 100%;
       border-radius: 0px 0px 20px 20px;
+
+      button {
+        display: inline-flex;
+        cursor: pointer;
+        align-items: center;
+        justify-content: center;
+        white-space: nowrap;
+        border-radius: 0.375rem;
+        font-size: 0.875rem;
+        font-weight: 500;
+        transition-property: color, background-color, border-color,
+          text-decoration-color, fill, stroke;
+        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+        transition-duration: 150ms;
+        background-color: #0bb489;
+        color: white;
+        padding: 0.5rem 1rem;
+        border: none;
+        outline: none;
+
+        &:focus-visible {
+          outline: 2px solid transparent;
+          outline-offset: 2px;
+          box-shadow: 0 0 0 2px var(--ring-color, #000);
+        }
+
+        &:disabled {
+          pointer-events: none;
+          opacity: 0.5;
+        }
+
+        &:hover {
+          background-color: rgba($color: #0bb489, $alpha: 0.8);
+        }
+      }
 
       h2 {
         color: black;

--- a/packages/payment-widget/src/lib/payment-widget.svelte
+++ b/packages/payment-widget/src/lib/payment-widget.svelte
@@ -22,6 +22,7 @@
   import { getSupportedCurrencies } from "./utils/currencies";
   import { initWalletConnector } from "./utils/walletConnector";
   import BuyerInfoForm from "./components/buyer-info-form.svelte";
+  import { ethers } from "ethers";
 
   // Props
   export let sellerInfo: SellerInfo;
@@ -37,6 +38,8 @@
   export let buyerInfo: BuyerInfo | undefined = undefined;
   export let enableBuyerInfo: boolean = true;
   export let invoiceNumber: string | undefined = undefined;
+  export let feeAddress: string = ethers.constants.AddressZero;
+  export let feeAmountInUSD: number = 0;
 
   // State
   let web3Modal: Web3Modal | null = null;
@@ -230,6 +233,8 @@
       />
     {:else if selectedCurrency && currentPaymentStep === "confirmation"}
       <PaymentConfirmation
+        {feeAddress}
+        {feeAmountInUSD}
         {enableBuyerInfo}
         {productInfo}
         {amountInUSD}

--- a/packages/payment-widget/src/lib/react/PaymentWidget.d.ts
+++ b/packages/payment-widget/src/lib/react/PaymentWidget.d.ts
@@ -21,6 +21,8 @@ export interface PaymentWidgetProps {
   buyerInfo?: BuyerInfo;
   enableBuyerInfo?: boolean;
   invoiceNumber?: string;
+  feeAddress?: string;
+  feeAmountInUSD?: number;
 }
 
 /**
@@ -70,6 +72,8 @@ export interface PaymentWidgetProps {
  *   onError={(error) => {
  *     console.error(error);
  *   }}
+ *   feeAddress="0x1234567890123456789012345678901234567890
+ *   feeAmountInUSD={22}
  * />
  */
 declare const PaymentWidget: React.FC<PaymentWidgetProps>;


### PR DESCRIPTION
resolves #127 

- Allows seller to pass in `feeAddress` and `feeAmountInUSD`.
- Convert `feeAmountInUSD` to selected payment currency.
- If `feeAddress` and `feeAmountInUSD` are valid, we show them to the buyer in the confirmation step and calculate the total.
- Add fee details to the payment note if `feeAddress` and `feeAmountInUSD` are valid.


### Payment without fee
![CleanShot 2024-09-26 at 14 57 29](https://github.com/user-attachments/assets/25064b42-3d61-4817-89b0-7fd5803657eb)
![CleanShot 2024-09-26 at 15 16 52](https://github.com/user-attachments/assets/c0449d5d-07e7-4eb4-922d-3936fee1c47e)

### Payment with fee
![CleanShot 2024-09-26 at 14 42 29](https://github.com/user-attachments/assets/43277b7f-1a1e-4cb3-82cc-aaba324fa620)
![CleanShot 2024-09-26 at 15 17 22](https://github.com/user-attachments/assets/f7e71731-b25c-4b05-978b-6391d432f390)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for transaction fees in the payment confirmation process.
	- Added new properties to display fee details, including fee address and amount in USD.
	- Updated UI to conditionally show fee information during payment.

- **Documentation**
	- Enhanced documentation for the PaymentWidget component to include examples of new fee-related properties. 

- **Bug Fixes**
	- Improved logic for handling fees in payment requests, ensuring accurate fee calculations and displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->