### PR TITLE
Add validator.js for email validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6471,6 +6471,13 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
+    "node_modules/@types/validator": {
+      "version": "13.12.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz",
+      "integrity": "sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -16863,6 +16870,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/valtio": {
       "version": "1.11.2",
       "license": "MIT",
@@ -17502,10 +17518,12 @@
         "@requestnetwork/data-format": "0.19.1",
         "@requestnetwork/request-client.js": "0.50.0",
         "@wagmi/core": "^2.13.8",
+        "validator": "^13.12.0",
         "viem": "^2.9.15"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.5.2",
+        "@types/validator": "^13.12.2",
         "svelte": "^4.0.5",
         "svelte-check": "^3.6.0",
         "typescript": "^5.0.0",

--- a/packages/create-invoice-form/package.json
+++ b/packages/create-invoice-form/package.json
@@ -36,10 +36,12 @@
     "@requestnetwork/data-format": "0.19.1",
     "@requestnetwork/request-client.js": "0.50.0",
     "@wagmi/core": "^2.13.8",
+    "validator": "^13.12.0",
     "viem": "^2.9.15"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.5.2",
+    "@types/validator": "^13.12.2",
     "svelte": "^4.0.5",
     "svelte-check": "^3.6.0",
     "typescript": "^5.0.0",

--- a/packages/create-invoice-form/src/lib/invoice/form.svelte
+++ b/packages/create-invoice-form/src/lib/invoice/form.svelte
@@ -17,6 +17,7 @@
   import { calculateItemTotal } from "@requestnetwork/shared-utils/invoiceTotals";
   import { checkAddress } from "@requestnetwork/shared-utils/checkEthAddress";
   import { inputDateFormat } from "@requestnetwork/shared-utils/formatDate";
+  import isEmail from "validator/es/lib/isEmail";
 
   export let config: IConfig;
   export const invoiceNumber: number = 1;
@@ -45,8 +46,7 @@
   }
 
   const validateEmail = (email: string, type: "sellerInfo" | "buyerInfo") => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    validationErrors[`${type}`].email = !emailRegex.test(email);
+    validationErrors[`${type}`].email = !isEmail(email);
   };
 
   const checkPayeeAddress = () => {


### PR DESCRIPTION
Fixes: [PR](https://github.com/orgs/RequestNetwork/projects/3/views/12?sliceBy%5Bvalue%5D=Sprint+18&filterQuery=assignee%3A%40me&pane=issue&itemId=84360075&issue=RequestNetwork%7Cweb-components%7C157)

### Proposed Solution
Replace the existing regex-based validation with the isEmail method from validator.js. This library provides robust and widely accepted email validation.

### Changes
- Added validator.js and types
- Changed the `validateEmail` function to use validator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced email validation functionality using the `validator` library.
  
- **Bug Fixes**
	- Improved accuracy of email validation by replacing custom logic with a standardized library function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->