### PR TITLE
Added tooltip and changed decimal point on amount

### DIFF
--- a/packages/invoice-dashboard/src/lib/view-requests.svelte
+++ b/packages/invoice-dashboard/src/lib/view-requests.svelte
@@ -563,7 +563,13 @@
                     </td>
                   {/if}
                   <td>
-                    {request.formattedAmount}
+                    {#if request.formattedAmount.includes(".") && request.formattedAmount.split(".")[1].length > 5}
+                      <Tooltip text={request.formattedAmount}>
+                        {Number(request.formattedAmount).toFixed(5)}
+                      </Tooltip>
+                    {:else}
+                      {request.formattedAmount}
+                    {/if}
                     {request.currencySymbol}
                   </td>
                   <td> {checkStatus(request)}</td>


### PR DESCRIPTION
Fixes [PR](https://github.com/orgs/RequestNetwork/projects/3/views/12?sliceBy%5Bvalue%5D=Sprint+18&filterQuery=assignee%3A%40me&pane=issue&itemId=84381261&issue=RequestNetwork%7Cweb-components%7C159)

### Problem
The "Expected Amount" field in the Invoice Dashboard currently displays values with full precision. This can result in excessively long and unwieldy numbers, negatively affecting readability and user experience.

### Proposed Solution

- Limit the displayed precision of the "Expected Amount" to 5 decimal places for improved readability.
- Add a tooltip to display the full precision value when users hover over the field, ensuring accessibility to complete information without compromising UI clarity.

### Changes Made

- Updated the logic for rendering the "Expected Amount" to truncate to 5 decimals while preserving full precision for the tooltip.
- Implemented a tooltip to display the full value when hovered.

![Screenshot 2024-11-18 at 08 38 36](https://github.com/user-attachments/assets/0456d9ae-541c-4132-b048-c54a1128f7bc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced display of formatted amounts in the requests table with improved tooltip functionality for clarity.
- **Bug Fixes**
	- Maintained existing functionality for requests, account changes, and sorting without introducing new errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->