### PR TITLE
Added formatting to checksum addresses

### DIFF
--- a/packages/create-invoice-form/src/lib/utils/prepareRequest.ts
+++ b/packages/create-invoice-form/src/lib/utils/prepareRequest.ts
@@ -1,6 +1,6 @@
+import { parseUnits, zeroAddress, getAddress } from "viem";
 import { Types, Utils } from "@requestnetwork/request-client.js";
 import type { CustomFormData } from "@requestnetwork/shared-types";
-import { parseUnits, zeroAddress } from "viem";
 
 interface IRequestParams {
   currency: any;
@@ -34,11 +34,11 @@ export const prepareRequestParams = ({
       ).toString(),
       payee: {
         type: Types.Identity.TYPE.ETHEREUM_ADDRESS,
-        value: formData.creatorId,
+        value: getAddress(formData.creatorId),
       },
       payer: {
         type: Types.Identity.TYPE.ETHEREUM_ADDRESS,
-        value: formData.payerAddress,
+        value: getAddress(formData.payerAddress),
       },
       timestamp: Utils.getCurrentTimestampInSecond(),
     },
@@ -49,7 +49,7 @@ export const prepareRequestParams = ({
           : Types.Extension.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT,
       parameters: {
         paymentNetworkName: currency.network,
-        paymentAddress: formData.payeeAddress,
+        paymentAddress: getAddress(formData.payeeAddress),
         feeAddress: zeroAddress,
         feeAmount: "0",
       },
@@ -122,7 +122,7 @@ export const prepareRequestParams = ({
     },
     signer: {
       type: Types.Identity.TYPE.ETHEREUM_ADDRESS,
-      value: address as string,
+      value: getAddress(address as string),
     },
   };
 };

--- a/packages/invoice-dashboard/src/utils/formatAddress.ts
+++ b/packages/invoice-dashboard/src/utils/formatAddress.ts
@@ -1,3 +1,4 @@
+import { getAddress } from "viem";
 import { checkAddress } from "@requestnetwork/shared-utils/checkEthAddress";
 
 export const formatAddress = (
@@ -9,5 +10,7 @@ export const formatAddress = (
     console.error("Invalid address!");
   }
 
-  return `${address.slice(0, first)}...${address.slice(-last)}`;
+  const checksumAddress = getAddress(address);
+
+  return `${checksumAddress.slice(0, first)}...${checksumAddress.slice(-last)}`;
 };


### PR DESCRIPTION
Fixes: [PR](https://github.com/orgs/RequestNetwork/projects/3/views/12?sliceBy%5Bvalue%5D=Sprint+18&filterQuery=assignee%3A%40me&pane=issue&itemId=84381765&issue=RequestNetwork%7Cweb-components%7C160)

### Problem
The Invoice Dashboard occasionally displays non-checksummed Ethereum addresses, which can lead to inconsistencies and reduced clarity. This issue arises because addresses retrieved from IPFS may be in lowercase.

### Changes Made

- Updated logic in the Invoice Dashboard to convert and display Ethereum addresses in checksummed format.
- Modified the Request creation process to ensure addresses are stored in checksummed format by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced address validation for Ethereum addresses in invoice creation and dashboard functionalities.
	- Improved formatting of Ethereum addresses to ensure valid checksum representation.

- **Bug Fixes**
	- Address handling errors are now logged for better troubleshooting.

- **Documentation**
	- Updated method signatures to reflect changes in address processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->