### PR TITLE
Remove blue background when autofilling

### DIFF
--- a/packages/create-invoice-form/src/lib/invoice/form.svelte
+++ b/packages/create-invoice-form/src/lib/invoice/form.svelte
@@ -702,6 +702,20 @@
     font-size: 12px;
   }
 
+  :global(input:-webkit-autofill),
+  :global(input:-webkit-autofill:hover),
+  :global(input:-webkit-autofill:focus),
+  :global(input:-webkit-autofill:active) {
+    -webkit-box-shadow: 0 0 0 30px white inset !important;
+    -webkit-text-fill-color: inherit !important;
+    transition: background-color 5000s ease-in-out 0s;
+  }
+
+  :global(input:autofill) {
+    background-color: white !important;
+    color: inherit !important;
+  }
+
   :global(.invoice-form-label-wrapper .input-wrapper) {
     flex: 1;
   }


### PR DESCRIPTION
FIxes: [PR](https://github.com/orgs/RequestNetwork/projects/3/views/12?sliceBy%5Bvalue%5D=Sprint+18&filterQuery=assignee%3A%40me&pane=issue&itemId=84409230&issue=RequestNetwork%7Cweb-components%7C169)

### Problem
The "Client Address" field in the Create Invoice Form incorrectly appears with a blue background, even when not selected. This issue occurs due to browser autofill styling, which makes the field visually inconsistent with others.

### Changes Made
- Updated CSS to override browser autofill styling for all fields.