### PR TITLE
Memo responsiveness fix

### DIFF
--- a/packages/create-invoice-form/src/lib/invoice/form-view.svelte
+++ b/packages/create-invoice-form/src/lib/invoice/form-view.svelte
@@ -457,7 +457,7 @@
   }
 
   .invoice-note-content {
-    width: 620px;
+    max-width: 620px;
     word-break: break-all;
   }
 


### PR DESCRIPTION
Fixes: [PR](https://github.com/orgs/RequestNetwork/projects/3/views/12?sliceBy%5Bvalue%5D=Sprint+18&filterQuery=assignee%3A%40me&pane=issue&itemId=84410370&issue=RequestNetwork%7Cweb-components%7C171)

### Problem
The "Memo" field in the Create Invoice Form breaks the form's responsiveness when content overflows, causing layout issues on smaller screens.

### Changes Made
- Modified the CSS for the "Memo" field to include max-width, preventing overflow while maintaining a clean layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced responsiveness of the invoice note content for better display on various screen sizes.

- **Bug Fixes**
	- Adjusted styling to ensure proper rendering of note content on smaller devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->