### PR TITLE
Updated form to use "Add Recipient Address"

### DIFF
--- a/packages/create-invoice-form/src/lib/invoice/form.svelte
+++ b/packages/create-invoice-form/src/lib/invoice/form.svelte
@@ -9,6 +9,7 @@
   // Icons
   import Trash from "@requestnetwork/shared-icons/trash.svelte";
   import Plus from "@requestnetwork/shared-icons/plus.svelte";
+  import Close from "@requestnetwork/shared-icons/close.svelte";
 
   // Types
   import type { IConfig, CustomFormData } from "@requestnetwork/shared-types";
@@ -39,11 +40,8 @@
     },
   };
 
-  let creatorId = "";
-
-  $: {
-    creatorId = formData.creatorId;
-  }
+  let creatorId = formData.creatorId || "";
+  let showPayeeAddressInput = false;
 
   const validateEmail = (email: string, type: "sellerInfo" | "buyerInfo") => {
     validationErrors[`${type}`].email = !isEmail(email);
@@ -129,6 +127,17 @@
   const removeInvoiceItem = (index: number) => {
     formData.invoiceItems = formData.invoiceItems.filter((_, i) => i !== index);
   };
+
+  const togglePayeeAddress = () => {
+    showPayeeAddressInput = !showPayeeAddressInput;
+    if (!showPayeeAddressInput) {
+      formData.payeeAddress = creatorId;
+    }
+  };
+
+  $: if (!showPayeeAddressInput && creatorId) {
+    formData.payeeAddress = creatorId;
+  }
 </script>
 
 <form class="invoice-form">
@@ -157,6 +166,38 @@
             label="From"
             placeholder="Connect wallet to populate"
           />
+          {#if !showPayeeAddressInput}
+            <Button
+              text="+ Add Recipient Address"
+              type="button"
+              onClick={togglePayeeAddress}
+              className="invoice-form-add-recipient-button"
+            />
+          {:else}
+            <div class="payee-address-container">
+              <Input
+                label="Where do you want to receive your payment?"
+                id="payeeAddress"
+                type="text"
+                value={formData.payeeAddress}
+                placeholder="0x..."
+                {handleInput}
+                onBlur={checkPayeeAddress}
+                error={validationErrors.payeeAddress
+                  ? "Please enter a valid Ethereum address"
+                  : ""}
+              />
+              <Button
+                type="button"
+                onClick={togglePayeeAddress}
+                className="invoice-form-close-recipient-button"
+              >
+                <div slot="icon" style="padding: 7px;">
+                  <Close />
+                </div>
+              </Button>
+            </div>
+          {/if}
           <Accordion title="Add Your Info">
             <div class="invoice-form-info">
               <Input
@@ -353,18 +394,6 @@
             label: `${currency.symbol} (${currency.network})`,
           }))}
           onchange={handleCurrencyChange}
-        />
-        <Input
-          label="Where do you want to receive your payment?"
-          id="payeeAddress"
-          type="text"
-          value={formData.payeeAddress}
-          placeholder="0x..."
-          {handleInput}
-          onBlur={checkPayeeAddress}
-          error={validationErrors.payeeAddress
-            ? "Please enter a valid Ethereum address"
-            : ""}
         />
       </div>
     </div>
@@ -594,6 +623,20 @@
     gap: 20px;
   }
 
+  :global(.invoice-form-add-recipient-button) {
+    background-color: transparent !important;
+    color: var(--mainColor) !important;
+    text-transform: uppercase;
+    transform: none !important;
+    font-weight: 500;
+    font-size: 14px !important;
+    width: fit-content;
+  }
+
+  :global(.invoice-form-add-recipient-button:hover) {
+    color: var(--secondaryColor) !important;
+  }
+
   .invoice-form-section {
     display: flex;
     flex-direction: column;
@@ -749,5 +792,26 @@
     ) {
     width: 12px;
     height: 12px;
+  }
+
+  .payee-address-container {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .payee-address-container :global(.input-wrapper) {
+    flex: 1;
+  }
+
+  :global(.invoice-form-close-recipient-button) {
+    position: absolute;
+    right: 0;
+    top: -4px;
+  }
+
+  :global(.invoice-form-close-recipient-button div) {
+    padding: 4px !important;
   }
 </style>

--- a/shared/components/button.svelte
+++ b/shared/components/button.svelte
@@ -17,7 +17,7 @@
   {type}
   {disabled}
   on:click={onClick}
-  class={`button ${padding} ${className} main-button`}
+  class={`button ${padding} main-button ${className}`}
 >
   {#if icon}
     <i class={icon.class} style={icon.style}></i>


### PR DESCRIPTION
Fixes https://github.com/RequestNetwork/web-components/issues/172

### Problem
The "Where would you like to receive your payment?" field is required in the Create Invoice Form, adding an unnecessary copy-paste step for most end-users. This is particularly inconvenient during Request Invoicing demonstrations, as the default Payee Identity address is the most commonly used.

### Changes Made
- Implemented the "Add Recipient Address" button to reveal the input field for a custom address.
- Added a "Close" button to revert the recipient address to the default (Payee Identity address) and hide the input.
- Ensured the UI updates dynamically to simplify the user flow while maintaining flexibility for customization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic management of the payee address input in the invoice form, allowing users to toggle visibility and validate Ethereum address format.
	- Added a button to easily add a recipient address when the input is hidden.

- **Style**
	- Updated button styling to ensure consistent UI appearance.

- **Bug Fixes**
	- Improved handling of `creatorId` to default to an empty string if not present, enhancing form reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->