### PR TITLE
Add IN/OUT Indicator Column to Invoice Dashboard

### DIFF
--- a/packages/invoice-dashboard/src/lib/view-requests.svelte
+++ b/packages/invoice-dashboard/src/lib/view-requests.svelte
@@ -12,6 +12,7 @@
   import Skeleton from "@requestnetwork/shared-components/skeleton.svelte";
   import Toaster from "@requestnetwork/shared-components/sonner.svelte";
   import Tooltip from "@requestnetwork/shared-components/tooltip.svelte";
+  import TxType from "@requestnetwork/shared-components/tx-type.svelte";
   import { toast } from "svelte-sonner";
   // Icons
   import ChevronDown from "@requestnetwork/shared-icons/chevron-down.svelte";
@@ -302,7 +303,11 @@
         paymentNetworkExtension?.id ===
           Types.Extension.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT
       ) {
-        paymentCurrencies = [currencyInfo as (CurrencyTypes.ERC20Currency | CurrencyTypes.NativeCurrency)];
+        paymentCurrencies = [
+          currencyInfo as
+            | CurrencyTypes.ERC20Currency
+            | CurrencyTypes.NativeCurrency,
+        ];
       } else {
         console.error(
           "Payment network extension not supported:",
@@ -539,6 +544,26 @@
                   </i>
                 </div>
               </th>
+              <th
+                on:click={() => {
+                  const sortBy = processedRequests?.some(
+                    (req) => req.payer?.value === signer
+                  )
+                    ? "payer.value"
+                    : "payee.value";
+                  handleSort(sortBy);
+                }}
+              >
+                <div>
+                  Type<i class={`caret `}>
+                    {#if sortOrder === "asc" && (sortColumn === "payer.value" || sortColumn === "payee.value")}
+                      <ChevronUp />
+                    {:else}
+                      <ChevronDown />
+                    {/if}
+                  </i>
+                </div>
+              </th>
               <th on:click={() => handleSort("state")}>
                 <div>
                   Status<i class={`caret `}>
@@ -622,6 +647,11 @@
                       {request.formattedAmount}
                     {/if}
                     {request.currencySymbol}
+                  </td>
+                  <td>
+                    <TxType
+                      type={signer === request.payer?.value ? "OUT" : "IN"}
+                    />
                   </td>
                   <td> {checkStatus(request)}</td>
                   <td

--- a/shared/components/tx-type.svelte
+++ b/shared/components/tx-type.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  export let type: "IN" | "OUT";
+
+  $: isOut = type === "OUT";
+</script>
+
+<div class="tx" class:out={isOut} class:in={!isOut}>
+  {type}
+</div>
+
+<style>
+  .tx {
+    padding: 8px 0px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    max-width: 40px;
+    width: 100%;
+    text-align: center;
+  }
+
+  .out {
+    background-color: rgba(255, 197, 49, 0.25);
+    color: #be7117;
+  }
+
+  .in {
+    background-color: rgba(11, 180, 137, 0.25);
+    color: #01503a;
+  }
+</style>


### PR DESCRIPTION
Fixes #163 

### Problem
In the All tab of the Invoice Dashboard, it's challenging for users to differentiate between incoming invoices ("pay", "accounts payable") and outgoing invoices ("get paid", "accounts receivable"), leading to potential confusion.

### Changes Made
- Created a reusable In/Out component to visually represent the direction of funds (incoming or outgoing).
- Integrated the new component into the Invoice Dashboard's All tab.
- Ensured the indicator column aligns with the design and improves user clarity.

<img width="1130" alt="Screenshot 2024-11-20 at 16 49 12" src="https://github.com/user-attachments/assets/572f5692-a018-459f-8295-a88c51a2ad5e">

<img width="1147" alt="Screenshot 2024-11-20 at 16 49 16" src="https://github.com/user-attachments/assets/e390196c-14e0-411d-9847-54189e283340">

<img width="1144" alt="Screenshot 2024-11-20 at 16 49 21" src="https://github.com/user-attachments/assets/4a2c0bfb-b281-4782-8501-707bcc60c003">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Type" column in the transaction table, displaying whether transactions are "IN" or "OUT" based on user role.
	- Added a new `TxType` component to enhance the display of transaction types.

- **Improvements**
	- Improved type clarity for payment currencies, facilitating better handling of different currency types.

- **Style**
	- New styles implemented for the `TxType` component to visually differentiate transaction types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->