### PR TITLE
fix: currency input type and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17512,7 +17512,7 @@
     },
     "packages/create-invoice-form": {
       "name": "@requestnetwork/create-invoice-form",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/data-format": "0.19.1",
@@ -17532,7 +17532,7 @@
     },
     "packages/invoice-dashboard": {
       "name": "@requestnetwork/invoice-dashboard",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/payment-detection": "0.45.1",
@@ -17567,7 +17567,7 @@
     },
     "packages/payment-widget": {
       "name": "@requestnetwork/payment-widget",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@requestnetwork/payment-processor": "0.48.0",

--- a/packages/create-invoice-form/src/lib/create-invoice-form.svelte
+++ b/packages/create-invoice-form/src/lib/create-invoice-form.svelte
@@ -27,7 +27,7 @@
   export let config: IConfig;
   export let wagmiConfig: WagmiConfig;
   export let requestNetwork: RequestNetwork | null | undefined;
-  export let currencies: any;
+  export let currencies: CurrencyTypes.CurrencyInput[] = [];
 
   let account: GetAccountReturnType;
   let isTimeout = false;

--- a/packages/invoice-dashboard/src/lib/view-requests.svelte
+++ b/packages/invoice-dashboard/src/lib/view-requests.svelte
@@ -46,7 +46,7 @@
   export let config: IConfig;
   export let wagmiConfig: WagmiConfig;
   export let requestNetwork: RequestNetwork | null | undefined;
-  export let currencies: any = [];
+  export let currencies: CurrencyTypes.CurrencyInput[] = [];
 
   let signer: `0x${string}` | undefined;
   let activeConfig = config ? config : defaultConfig;

--- a/shared/utils/initCurrencyManager.ts
+++ b/shared/utils/initCurrencyManager.ts
@@ -1,4 +1,5 @@
 import { CurrencyManager } from "@requestnetwork/currency";
+import { CurrencyTypes } from "@requestnetwork/types";
 
 const defaultCurrencyIds = [
   "USD",
@@ -64,7 +65,7 @@ import { Types } from "@requestnetwork/request-client.js";
 import { formattedCurrencyConversionPairs } from './currencyConversionPairs'
 
 export function initializeCurrencyManager(
-  customCurrencies: any[] = []
+  customCurrencies: CurrencyTypes.CurrencyInput[] = []
 ): CurrencyManager {
   let currenciesToUse: any[];
 
@@ -113,7 +114,7 @@ export function initializeCurrencyManagerWithCurrencyIDS(
 }
 
 export const getCurrencySupportedNetworksForConversion = (currencyHash: string, currencyManager: any) : (string | undefined)[] => {
- return Object.keys(currencyManager.conversionPairs).filter((network) => 
+ return Object.keys(currencyManager.conversionPairs).filter((network) =>
     currencyManager.conversionPairs[network][currencyHash]
  );
 }


### PR DESCRIPTION
# Problems

1. `currencies` input parameter was accidentally changed to `CurrencyDefinition[]` type in #141 when it should have been `CurrencyInput[]` type.
2. package-lock.json was out of sync

# Changes

1. Make `currencies` input parameter `CurrencyInput[]` type.
2. Fix package-lock.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety for currency inputs in the invoice form and dashboard components.
	- Improved error handling during invoice submission.

- **Bug Fixes**
	- Adjusted logic to ensure accurate updates of currencies and networks based on user selections.

- **Documentation**
	- Updated method signatures and return types for better clarity and specificity regarding currency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->