### PR TITLE
chore: release create-request-form@0.9.1 and invoice-dashboard@0.8.1

### DIFF
--- a/packages/create-invoice-form/package.json
+++ b/packages/create-invoice-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestnetwork/create-invoice-form",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "./dist/web-component.umd.cjs",
   "scripts": {
     "dev": "vite dev",

--- a/packages/invoice-dashboard/package.json
+++ b/packages/invoice-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestnetwork/invoice-dashboard",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "./dist/web-component.umd.cjs",
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
# Problem

Previous stable releases had incorrect interface for `currencies` argument. It also had unsynchronized `viem` dependency versions.