### PR TITLE
Center modal overflow fix

### DIFF
--- a/packages/invoice-dashboard/src/lib/dashboard/drawer.svelte
+++ b/packages/invoice-dashboard/src/lib/dashboard/drawer.svelte
@@ -50,8 +50,11 @@
     left: 50%;
     height: fit-content;
     width: 800px;
-
+    max-height: 90vh;
+    overflow-y: auto;
+    overflow-x: hidden;
     transform: translateX(0);
+    padding-right: 20px;
   }
 
   @media only screen and (max-width: 880px) {


### PR DESCRIPTION
### Problem

When the modal is centered and has a lot of information, it goes over the screen.

### Changes

- Added overflow scroll
- Height is 90 viewport height
- Added padding on right because of the scroll bar