### PR TITLE
fix: switch network button disabled

### DIFF
--- a/packages/invoice-dashboard/src/lib/dashboard/invoice-view.svelte
+++ b/packages/invoice-dashboard/src/lib/dashboard/invoice-view.svelte
@@ -395,6 +395,7 @@
   async function approve() {
     try {
       loading = true;
+      isSigningTransaction = true;
 
       const approvers: { [key: string]: () => Promise<void> } = {
         [Types.Extension.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT]:
@@ -429,6 +430,7 @@
       console.error("Something went wrong while approving ERC20: ", err);
     } finally {
       loading = false;
+      isSigningTransaction = false;
     }
   }
 
@@ -504,7 +506,6 @@
           token: paymentCurrencies[0].address as `0x${string}`,
           chainId: invoiceNetworkId,
         });
-        ;
         userBalance = balance.formatted;
         hasEnoughBalance = balance.value >= BigInt(request.expectedAmount);
       } else {
@@ -849,7 +850,9 @@
             : "Pay Now"}
         padding="px-[12px] py-[6px]"
         onClick={handlePayment}
-        disabled={!hasEnoughBalance}
+        disabled={correctChain
+          ? !hasEnoughBalance && !isSigningTransaction
+          : false}
       />
     {/if}
   </div>

--- a/packages/invoice-dashboard/src/lib/dashboard/invoice-view.svelte
+++ b/packages/invoice-dashboard/src/lib/dashboard/invoice-view.svelte
@@ -834,7 +834,7 @@
   {/if}
   <div class="invoice-view-actions">
     {#if !isPayee && !unsupportedNetwork && !isPaid && !isRequestPayed && !isSigningTransaction}
-      {#if !hasEnoughBalance}
+      {#if !hasEnoughBalance && correctChain}
         <div class="balance-warning">
           Insufficient funds: {Number(userBalance).toFixed(4)}
           {paymentCurrencies[0]?.symbol || "-"}
@@ -851,7 +851,7 @@
         padding="px-[12px] py-[6px]"
         onClick={handlePayment}
         disabled={correctChain
-          ? !hasEnoughBalance && !isSigningTransaction
+          ? !hasEnoughBalance || isSigningTransaction
           : false}
       />
     {/if}


### PR DESCRIPTION
Fixes #285
Fixes #287
- #285
- #287 

### Problem 

- Approve button is being disabled because we didn't let the actual balance check to go trough on the right network

### Changes

- Now we are checking if we are on the right chain, then if we are, we are checking if the user is signing a transaction or has enough balance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved transaction signing and approval processes with enhanced user feedback.
	- Added state management for transaction signing status during approval and payment actions.
	- Conditional button disabling to prevent actions during ongoing processes.

- **Bug Fixes**
	- Enhanced error handling with specific notifications for payment and approval issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->