### PR TITLE
chore: change default dueDate to 30 days

### DIFF
--- a/packages/create-invoice-form/src/lib/invoice/form.svelte
+++ b/packages/create-invoice-form/src/lib/invoice/form.svelte
@@ -29,7 +29,8 @@
   export let handleNetworkChange: (chainId: string) => void;
   export let networks;
   export let defaultCurrencies: any = [];
-  export let filteredSettlementCurrencies: CurrencyTypes.CurrencyDefinition[] = [];
+  export let filteredSettlementCurrencies: CurrencyTypes.CurrencyDefinition[] =
+    [];
   export let cipherProvider: CipherProviderTypes.ICipherProvider | undefined;
 
   export let invoiceCurrencyDropdown;
@@ -161,7 +162,7 @@
 
   $: if (!formData.dueDate) {
     formData.dueDate = inputDateFormat(
-      new Date(new Date(formData.issuedOn).getTime() + 24 * 60 * 60 * 1000)
+      new Date(new Date(formData.issuedOn).getTime() + 30 * 24 * 60 * 60 * 1000)
     );
   }
 </script>
@@ -406,8 +407,7 @@
           <SearchableDropdown
             bind:this={invoiceCurrencyDropdown}
             getValue={(currency) => currency.value.symbol}
-            getDisplayValue={(currency) =>
-              `${currency.value.symbol}`}
+            getDisplayValue={(currency) => `${currency.value.symbol}`}
             placeholder="Invoice currency"
             items={defaultCurrencies
               ?.filter((curr) => curr)
@@ -419,7 +419,7 @@
             onSelect={handleInvoiceCurrencyChange}
           />
         </div>
-        <div class="searchable-dropdown-container"> 
+        <div class="searchable-dropdown-container">
           <SearchableDropdown
             bind:this={networkDropdown}
             items={networks


### PR DESCRIPTION
Fixes #279 

### Problem
The current Due Date field defaults to 1 day, which is not aligned with invoicing industry conventions and may lead to confusion or inefficiency for users.

### Changes 
- Modified the logic in the web component to set the default Due Date to 30 days.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Extended the default due date from 1 day to 30 days after the issued date in the invoice form.
  
- **Improvements**
	- Enhanced clarity in the initialization of settlement currencies.
	- Minor adjustments to the currency dropdown for consistent formatting. 

- **Bug Fixes**
	- Maintained existing functionality for adding and removing invoice items without any issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->