### PR TITLE
fix: updated logic for pay now button

### DIFF
--- a/packages/invoice-dashboard/src/lib/dashboard/invoice-view.svelte
+++ b/packages/invoice-dashboard/src/lib/dashboard/invoice-view.svelte
@@ -100,6 +100,10 @@
 
   let isSigningTransaction = false;
 
+  let initialPaymentCheck = false;
+
+  let showPaymentButton = true;
+
   const generateDetailParagraphs = (info: any) => {
     const fullName = [info?.firstName, info?.lastName]
       .filter(Boolean)
@@ -154,6 +158,12 @@
   $: {
     if (request?.requestId !== previousRequestId) {
       previousRequestId = request?.requestId;
+      initialPaymentCheck =
+        request?.state === "paid" ||
+        request?.state === "overpaid" ||
+        status === "paid" ||
+        status === "overpaid" ||
+        request?.balance?.balance >= request?.expectedAmount;
       checkInvoice();
     }
   }
@@ -345,6 +355,7 @@
       isPaid = true;
       status = checkStatus(requestData);
       isRequestPayed = true;
+      showPaymentButton = false; // Hide the button after successful payment
     } catch (err) {
       console.error("Something went wrong while paying : ", err);
 
@@ -857,7 +868,7 @@
       {/each}
     {/if}
   </div>
-  {#if !isPaid && !isPayee}
+  {#if !isPayee && !initialPaymentCheck}
     <div class="status-container">
       <div class="statuses">
         {#if statuses?.length > 0}
@@ -920,7 +931,7 @@
     </div>
   {/if}
   <div class="invoice-view-actions">
-    {#if !isPayee && !unsupportedNetwork && !isPaid && !isRequestPayed && !isSigningTransaction && !unknownCurrency}
+    {#if showPaymentButton && !isPayee && !unsupportedNetwork && !isSigningTransaction && !unknownCurrency && !initialPaymentCheck}
       {#if !hasEnoughBalance && correctChain}
         <div class="balance-warning">
           Insufficient funds: {Number(userBalance).toFixed(4)}


### PR DESCRIPTION
Fixes: #321 

### Problem

The "Pay Now" button is missing in the Invoice View when attempting to pay a second invoice. This issue was observed when a user pays an invoice, then tries to pay a subsequent one—the button does not appear until the page is refreshed.

### Changes
- Updated the payment logic in the invoice-view component to ensure the "Pay Now" button is consistently displayed.
- Refactored the button visibility logic so that after a payment attempt (or failure), the button remains accessible for subsequent payments without requiring a page refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the display of invoice payment status for a more refined user experience.
  - Updated the payment button logic to appear only when appropriate and automatically hide after a successful payment to prevent duplicate charges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->